### PR TITLE
DMD64 fixes

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"derelict-util": "2.0.0",
+		"derelict-util": "2.0.3",
 		"derelict-physfs": "1.0.0"
 	}
 }

--- a/source/raider/tools/reference.d
+++ b/source/raider/tools/reference.d
@@ -480,7 +480,7 @@ if(C == "R" || C == "W" || C == "P")
 				//numeric types don't need destruction
 				_void = o;
 				
-				assert(header.pointerCount == 0);
+        version(assert) assert(header.pointerCount == 0);
 			}
 		}
 

--- a/source/raider/tools/reference.d
+++ b/source/raider/tools/reference.d
@@ -50,6 +50,7 @@ import core.atomic;
 import core.exception : onOutOfMemoryError;
 import core.memory : GC;
 import core.stdc.stdlib : malloc, free;
+import core.vararg;
 import raider.tools.array;
 
 //Evaluates true if a type T has collectable fields.


### PR DESCRIPTION
This branch applies some fixes that allow the package to compile under DMD64.
- On DMD64, the length of an array is stored in a `ulong`. This differs from DMD32, which stores it in a `uint`. This branch fixes the type mismatch when passing the length of an array to either `PHYSFS_write` or `PHYSFS_read`.
- I'm not sure if this is a DMD64 issue or a Dlang 2.068 issue, actually, but variadic functions don't work without an `import code.vararg` directive.
- When building with `dub -b release`, there's a failing assert. I've just updated the assert by prefixing it with `version(assert)`, though I feel like this is something that should be handled by the compiler?
### Known Issues

Running `dub test` still does not work, as I get an error telling me to compile `derelict-physfs` with the `-fPIC` flag. I can't find anything in dub's documentation for passing flags when compiling dependencies, so we may need to add `derelict-physfs` as a submodule. Will open an issue or PR about it at some point.
